### PR TITLE
Changes to compile on macOS.

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -2,9 +2,9 @@
 #ifndef __DEFINES_H__
 #define __DEFINES_H__
 
-#if __unix__
+#if __unix__ || (defined(__APPLE__) && defined(__MACH__))
 # define UNIX 1
-# if __NetBSD__
+# if __NetBSD__ || (defined(__APPLE__) && defined(__MACH__))
 #  define BSD 1
 #  define POSIX 1
 # elif __linux__

--- a/main.c
+++ b/main.c
@@ -69,6 +69,7 @@
 #include "defines.h"	/* OS specific customization */
 #if UNIX
 # include <signal.h>
+# include <unistd.h>
 #endif
 
 #include "basic.h"


### PR DESCRIPTION
Hello. This commit has a couple of changes to allow this uemacs to be compiled on macOS. Thanks for your consideration.

defines.h:
  Use (defined(__APPLE__) && defined(__MACH__)) to
  detect macOS, as suggested by https://stackoverflow.com/questions/7063303/macro-unix-not-defined-in-macos-x.
  Combined with __NetBSD__ to set BSD=1 and POSIX=1.

main.c:
  Include <unistd.h> to pick up sleep() declaration.