### PR TITLE
Simple changes for porting to non-UNIX systems.

### DIFF
--- a/input.c
+++ b/input.c
@@ -693,10 +693,12 @@ int getstring( const char *prompt, char *buf, int nbuf, int eolchar)
     }
 
 	TTflush() ;
+#if UNIX
 	if( tmpf != NULL) {
 		fclose( tmpf) ;
 		unlink( tmp) ;
 	}
+#endif
 
 	return retval ;
 }

--- a/spawn.c
+++ b/spawn.c
@@ -69,6 +69,8 @@ BINDABLE( spawncli) {
 	term.t_nrow = term.t_ncol = 0;
 #endif
 	return TRUE;
+#else
+        return FALSE;
 #endif
 }
 
@@ -100,14 +102,14 @@ void rtfrmshell(void)
  * done. Bound to "C-X !".
  */
 BINDABLE( spawn) {
-	int s ;
-	char *line ;
 
 	/* don't allow this command if restricted */
 	if( restflag)
 		return resterr();
 
 #if	USG | BSD
+	int s ;
+	char *line ;
 	s = newmlarg( &line, "!", 0) ;
 	if( s != TRUE)
 		return s ;
@@ -129,6 +131,8 @@ BINDABLE( spawn) {
 	TTkopen();
 	sgarbf = TRUE;
 	return TRUE;
+#else
+	return FALSE;
 #endif
 }
 
@@ -139,14 +143,14 @@ BINDABLE( spawn) {
  */
 
 BINDABLE( execprg) {
-	int s ;
-	char *line ;
 
 	/* don't allow this command if restricted */
 	if( restflag)
 		return resterr() ;
 
 #if	USG | BSD
+	int s ;
+	char *line ;
 	s = newmlarg( &line, "$", 0) ;
 	if( s != TRUE)
 		return s ;
@@ -164,6 +168,8 @@ BINDABLE( execprg) {
 	while ((s = tgetc()) != '\r' && s != ' ');
 	sgarbf = TRUE;
 	return TRUE;
+#else
+	return FALSE;
 #endif
 }
 

--- a/tcap.c
+++ b/tcap.c
@@ -6,6 +6,8 @@
  *	modified by Petri Kutvonen
  */
 
+#if TERMCAP
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -23,8 +25,6 @@
 #include "defines.h"
 #include "display.h"
 #include "termio.h"
-
-#if TERMCAP
 
 boolean eolexist = TRUE ;	/* does clear to EOL exist      */
 boolean revexist = FALSE ;	/* does reverse video exist?    */

--- a/termio.c
+++ b/termio.c
@@ -228,6 +228,7 @@ int ttgetc( void) {
     }
     return kbdq & 255;
 #endif
+    return 0;
 }
 
 #if TYPEAH


### PR DESCRIPTION
I'm interested in porting this uemacs 'back' to the Atari ST. This commit has a few simple changes to allow compilation on a non-UNIX, non-TERMCAP system. Thanks for your consideration.

input.c: The tmpf variable is defined inside an #if UNIX block at line
         506, but used outside of an #if UNIX block at line 696. Added
         #if UNIX there.

spawn.c:
    - For spawncli(), return FALSE if neither USB ot BSD is defined.
    - In spawn() and execprg(), move declarations inside USB | BSD
      block.

tcap.c: Move #if TERMCAP to avoid curses.h include on non-TERMCAP
        systems.

termio.c: For ttgetc(), return 0 if neither USG nor BSD is defined.